### PR TITLE
fixing securitycontext values to work for openshift

### DIFF
--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -30,12 +30,9 @@ spec:
       affinity:
       {{- toYaml .Values.deployment.affinity.data | nindent 8 }}
       {{- end }}
-      {{- if .Values.deployment.securityContext }}
-        {{- if .Values.deployment.securityContext.enabled }}
+      {{- if .Values.podSecurityContext.enabled }}
       securityContext:
-         runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
-         fsGroup: {{ .Values.deployment.securityContext.fsGroup }}
-        {{- end }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
       {{- end }}
       serviceAccountName: {{ template "akeyless-api-gw.getServiceAccountName" . }}
       {{- if .Values.deployment.nodeSelector }}
@@ -121,6 +118,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.containerSecurityContext.runAsUser }}
+          {{- end }}
           ports:
             - name: web
               containerPort: 18888

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -18,6 +18,24 @@ httpProxySettings:
   https_proxy: ""
   no_proxy: ""
 
+## Configure Pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enable pods' Security Context
+## @param podSecurityContext.fsGroup pods' group ID
+##
+podSecurityContext:
+  enabled: false
+  fsGroup: 0
+## Configure Container Security Context (only main container)
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param containerSecurityContext.enabled Enable containers' Security Context
+## @param containerSecurityContext.runAsUser containers' Security Context
+##
+containerSecurityContext:
+  enabled: false
+  runAsUser: 0
+
+
 deployment:
   annotations: {}
   labels: {}
@@ -53,10 +71,6 @@ deployment:
   fips:
     enabled: false
 
-  securityContext:
-    enabled: false
-    fsGroup: 0
-    runAsUser: 0
 service:
   # Remove the {} and add any needed annotations regarding your LoadBalancer implementation
   annotations: {}


### PR DESCRIPTION
Used bitnami helm charts as guide. specifically https://github.com/bitnami/charts/tree/main/bitnami/joomla (but there are plenty of others).

The idea is that the `fsGroup` should be part of the POD Security Context and the `runAsUser` should be part of the Container Security Context. 